### PR TITLE
test: Ensure local dependencies are up-to-date

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,13 +9,6 @@ jobs:
     strategy:
       matrix:
         node-version: [18.x]
-        package:
-          - cli
-          - core
-          - matchers
-          - parser
-          - rebuild-matchers
-          - utils
 
     env:
       CI: true
@@ -32,14 +25,5 @@ jobs:
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build
-        working-directory: packages/${{ matrix.package }}
-        run: pnpm build
-
-      - name: Run Linter
-        working-directory: packages/${{ matrix.package }}
-        run: pnpm lint
-
-      - name: Run Tests
-        working-directory: packages/${{ matrix.package }}
-        run: pnpm test
+      - name: Check
+        run: pnpm check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -23,7 +23,7 @@ $ pnpm install
 Then make sure the tests pass:
 
 ```sh
-$ pnpm test
+$ pnpm check
 ```
 
 ### Running linting/testing

--- a/package.json
+++ b/package.json
@@ -42,7 +42,10 @@
     "typescript": "^4.4.4"
   },
   "scripts": {
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "build": "pnpm run --recursive build",
+    "lint": "pnpm run --parallel --recursive lint",
+    "check": "pnpm build && pnpm lint && pnpm run --parallel --recursive test"
   },
   "packageManager": "pnpm@10.14.0+sha512.ad27a79641b49c3e481a16a805baa71817a04bbe06a38d17e60e2eaee83f6a146c6a688125f5792e48dd5ba30e7da52a5cda4c3992b9ccf333f9ce223af84748"
 }

--- a/packages/cli/__tests__/cli/extensions.test.ts
+++ b/packages/cli/__tests__/cli/extensions.test.ts
@@ -6,6 +6,8 @@ import createTemporaryFile, {
 import plugin from '../helpers/plugin'
 import { runCodemodCLI } from '../helpers/runCodemodCLI'
 
+jest.setTimeout(10_000)
+
 test('can load plugins written with ES modules by default', async function () {
   const afile = await createTemporaryFile('a-file.js', '3 + 4;')
   expect(

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -20,9 +20,9 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "prepublishOnly": "pnpm clean && pnpm build",
-    "test": "is-ci test:coverage test:watch",
-    "test:coverage": "jest --coverage",
-    "test:watch": "jest --watch"
+    "test": "is-ci test:coverage test:basic",
+    "test:basic": "jest",
+    "test:coverage": "jest --coverage"
   },
   "dependencies": {
     "@babel/core": "^7.20.12",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -16,9 +16,9 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "prepublishOnly": "pnpm clean && pnpm build",
-    "test": "is-ci test:coverage test:watch",
-    "test:coverage": "jest --coverage",
-    "test:watch": "jest --watch"
+    "test": "is-ci test:coverage test:basic",
+    "test:basic": "jest",
+    "test:coverage": "jest --coverage"
   },
   "dependencies": {
     "@babel/core": "^7.20.12",

--- a/packages/matchers/package.json
+++ b/packages/matchers/package.json
@@ -16,9 +16,9 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "prepublishOnly": "pnpm clean && pnpm build",
-    "test": "is-ci test:coverage test:watch",
-    "test:coverage": "jest --coverage",
-    "test:watch": "jest --watch"
+    "test": "is-ci test:coverage test:basic",
+    "test:basic": "jest",
+    "test:coverage": "jest --coverage"
   },
   "dependencies": {
     "@babel/types": "^7.20.7",

--- a/packages/parser/package.json
+++ b/packages/parser/package.json
@@ -16,9 +16,9 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "prepublishOnly": "pnpm clean && pnpm build",
-    "test": "is-ci test:coverage test:watch",
-    "test:coverage": "jest --coverage",
-    "test:watch": "jest --watch"
+    "test": "is-ci test:coverage test:basic",
+    "test:basic": "jest",
+    "test:coverage": "jest --coverage"
   },
   "dependencies": {
     "@babel/parser": "^7.20.15"

--- a/packages/rebuild-matchers/package.json
+++ b/packages/rebuild-matchers/package.json
@@ -17,9 +17,9 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "prepublishOnly": "pnpm clean && pnpm build",
-    "test": "is-ci test:coverage test:watch",
-    "test:coverage": "jest --coverage",
-    "test:watch": "jest --watch"
+    "test": "is-ci test:coverage test:basic",
+    "test:basic": "jest",
+    "test:coverage": "jest --coverage"
   },
   "dependencies": {
     "@babel/types": "^7.20.7",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -16,9 +16,9 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "prepublishOnly": "pnpm clean && pnpm build",
-    "test": "is-ci test:coverage test:watch",
-    "test:coverage": "jest --coverage",
-    "test:watch": "jest --watch"
+    "test": "is-ci test:coverage test:basic",
+    "test:basic": "jest",
+    "test:coverage": "jest --coverage"
   },
   "dependencies": {
     "@babel/core": "^7.20.12",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,5 +4,8 @@ packages:
 autoInstallPeers: false
 linkWorkspacePackages: deep
 
+syncInjectedDepsAfterScripts:
+  - build
+
 onlyBuiltDependencies:
   - esbuild


### PR DESCRIPTION
While jest will run a package and its tests without needing a build step, it will use the last-built version of the other packages for its dependencies, so we're not actually guaranteed to be testing the latest state unless we build all of a package's local dependencies before we start testing it.

It's not impossible that that was being handled somehow, but I'm about 95% sure it was not.

The `test:watch` scripts have been removed, as a watch mode that tests without building is not reliable. If they're deemed important enough, I can add watch scripts back in, in a form that handles building as well (maybe with `tsc --build`?).

I don't think any local packages are getting injected, but I added `syncInjectedDepsAfterScripts` to `pnpm-workspace.yaml` to be safe.